### PR TITLE
fixed initialization, changed cd command to nicer syntax

### DIFF
--- a/src/angle.cpp
+++ b/src/angle.cpp
@@ -125,11 +125,11 @@ int main(int argc, char **argv) {
  ros::NodeHandle n;
  Angle angle(n);
  ROS_INFO("Woking fine, son!");
- matlab::Engine engine;
+ matlab::Engine engine(true);
 
  double a = 3;
  engine.put("a",a);
- engine.executeCommand("cd('~/catkin_ws/src/scalaser/matlab')"); // Path to matlab function
+ engine.changeWorkingDirectory("src/scalaser/matlab"); // Path to matlab function
  engine.executeCommand("test()");
  ROS_INFO("NOT WORKING");
  engine.openCommandLine();


### PR DESCRIPTION
Hi Miro. You forgot to initialize Matlab. I will change the Matlab interface so it throws an error. Build works fine on my machine and also the "put(a)" command acutally puts a to matlab. Just hit
> a
in the console to see it. Alternatively, you can also type
> openvar('a')
All these commands also work with "engine.executeCommand()".
